### PR TITLE
Allow any keyboard event to add class to the <html>

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ import HasTabbed from 'has-tabbed';
 const tabbed = new HasTabbed('my-super-duper-class');
 ```
 
+### config
+To treat any keyboard event as tab (e.g. custom focus handling) pass a config object as a parameter:
+
+```js
+const config = {
+  className: 'my-super-duper-class',
+  treatAnyKeyboardEventAsTab: true
+};
+
+const tabbed = new HasTabbed(config);
+```
+
 ## Old school usage
 
 You should use ES modules, but you can use it directly in the browser.

--- a/has-tabbed.js
+++ b/has-tabbed.js
@@ -1,11 +1,19 @@
 'use strict';
 
 (function() {
-  var TAB_KEY_CODE = 9;
-  var DEFAULT_CLASSNAME = '--tabbed';
+  var DEFAULTS = {
+    treatAnyKeyboardEventAsTab: false,
+    className: '--tabbed'
+  };
 
-  function HasTabbed(className) {
-    this.className = className || DEFAULT_CLASSNAME;
+  function HasTabbed(config) {
+    if (typeof config === 'string') {
+      this.className = config;
+    } else if (typeof config === 'object') {
+      Object.assign(this, DEFAULTS, config);
+    } else {
+      Object.assign(this, DEFAULTS);
+    }
 
     if (typeof document === 'undefined') {
       // Server side rendering
@@ -28,7 +36,7 @@
   };
 
   HasTabbed.prototype.handleKeyDown = function(e) {
-    if (e.keyCode === TAB_KEY_CODE) {
+    if (e.key === 'Tab' || this.treatAnyKeyboardEventAsTab) {
       this.htmlClassList.add(this.className);
     }
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "has-tabbed",
-  "version": "0.9.1",
+  "version": "0.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "has-tabbed",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Small library that adds CSS class to html when user starts tabbing, and removes it if user clicks anywhere.",
   "main": "has-tabbed.js",
   "scripts": {


### PR DESCRIPTION
Custom focus management for arrow keys doesn't trigger focus outline if the key arrow event was preceded by a non-keyboard interaction. This change allows authors to opt into triggering focus styles on any keyboard event.

Replaced deprecated `.keyCode` with `.key`.